### PR TITLE
Adding an Arabic Translation for AH2

### DIFF
--- a/language/resource.language.ar_sa/strings.po
+++ b/language/resource.language.ar_sa/strings.po
@@ -1,0 +1,1302 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-22 00:41+0000\n"
+"PO-Revision-Date: 2022-07-23 04:09+0000\n"
+"Last-Translator: psp2111-ADSLGATE <>\n"
+"Language-Team: Arabic (Saudi Arabia)\n"
+"Language: ar-SA\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Loco-Source-Locale: ar_SA\n"
+"X-Generator: Loco https://localise.biz/\n"
+"X-Loco-Parser: loco_parse_po"
+
+#: 1080i/SettingsSystemInfo.xml
+msgctxt "#31000"
+msgid "Live TV / PVR"
+msgstr "البث المباشر / PVR"
+
+#: 1080i/Custom_Colors_1101.xml
+msgctxt "#31001"
+msgid "Select colours"
+msgstr "اختيار الألوان"
+
+#: 1080i/Items.xml
+msgctxt "#31002"
+msgid "Manage"
+msgstr "إدارة"
+
+#: 1080i/Custom_Colors_1101.xml
+msgctxt "#31003"
+msgid "Change"
+msgstr "تغيير"
+
+#: 1080i/MyWeather.xml
+msgctxt "#31004"
+msgid "Weekly Forecast"
+msgstr "التوقعات الأسبوعية"
+
+#: 1080i/MyWeather.xml
+msgctxt "#31005"
+msgid "Rain Chance"
+msgstr "فرصة هطول المطر"
+
+#: 1080i/Items.xml
+msgctxt "#31006"
+msgid "Location"
+msgstr "الموقع"
+
+#: 1080i/Items.xml
+msgctxt "#31007"
+msgid "Customise appearance"
+msgstr "تخصيص الشكل"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31008"
+msgid "Image"
+msgstr "صورة"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31009"
+msgid "Blur"
+msgstr "ضبابي"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31010"
+msgid "ClearArt"
+msgstr ""
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31011"
+msgid "Small Fanart"
+msgstr "Fanart بحجم صغير"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31012"
+msgid "Keyart"
+msgstr ""
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31013"
+msgid "Text"
+msgstr "النص"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31014"
+msgid "Clearlogo"
+msgstr ""
+
+#: 1080i/Items.xml
+msgctxt "#31015"
+msgid "Order"
+msgstr "الترتيب"
+
+#: 1080i/Items.xml
+msgctxt "#31016"
+msgid "Sort by"
+msgstr "فرز حسب"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31017"
+msgid "File Details"
+msgstr "تفاصيل الملف"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31018"
+msgid "Recommendations"
+msgstr "التوصيات"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31019"
+msgid "Crew"
+msgstr "طاقم الإنتاج"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31020"
+msgid "lists"
+msgstr "القوائم"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31021"
+msgid "Similar"
+msgstr "عمل مشابه"
+
+#: 1080i/Dialogs.xml
+msgctxt "#31022"
+msgid "items"
+msgstr "العناصر"
+
+#: 1080i/Objects.xml
+msgctxt "#31023"
+msgid "Loading"
+msgstr "جار تحميل"
+
+#: 1080i/Labels.xml
+msgctxt "#31024"
+msgid "Critics Consensus"
+msgstr "إجماع النقاد"
+
+#: 1080i/DialogAddonInfo.xml
+msgctxt "#31025"
+msgid "Add-on ID"
+msgstr ""
+
+#: 1080i/DialogAddonInfo.xml
+msgctxt "#31026"
+msgid "Origin"
+msgstr "المنشأ"
+
+#: 1080i/Labels.xml
+msgctxt "#31027"
+msgid "Not installed"
+msgstr "غير مثبتة"
+
+#: 1080i/Dialogs.xml
+msgctxt "#31028"
+msgid "Outline"
+msgstr "الحبكة"
+
+#: 1080i/Items.xml
+msgctxt "#31029"
+msgid "Updated"
+msgstr "محدث"
+
+#: 1080i/Items.xml
+msgctxt "#31030"
+msgid "Installed"
+msgstr "مثبتة"
+
+#: 1080i/MyWeather.xml
+msgctxt "#31031"
+msgid "Weather Forecast for"
+msgstr "توقعات الطقس لـ"
+
+#: 1080i/Custom_Discover_1116.xml
+msgctxt "#31032"
+msgid "Filters"
+msgstr "الفلاتر"
+
+#: 1080i/Labels.xml
+msgctxt "#31033"
+msgid "People"
+msgstr "اشخاص"
+
+#: 1080i/Labels.xml
+msgctxt "#31034"
+msgid "Cast member"
+msgstr "عضو طاقم التمثيل"
+
+#: 1080i/Labels.xml
+msgctxt "#31035"
+msgid "Crew member"
+msgstr "عضو في طاقم الإنتاج"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31036"
+msgid "Balanced"
+msgstr "متوازن"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31037"
+msgid "Quality"
+msgstr "جودة"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31038"
+msgid "Performance"
+msgstr "أداء"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31039"
+msgid "Background style"
+msgstr "نمط الخلفية"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31040"
+msgid "Foreground"
+msgstr "المقدمة"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31041"
+msgid "FlixArt"
+msgstr ""
+
+#: 1080i/Labels.xml
+msgctxt "#31042"
+msgid "Discover"
+msgstr "اكتشف"
+
+#: 1080i/Custom_Colors_1111.xml
+msgctxt "#31043"
+msgid "Flat (No Gradient)"
+msgstr "لون واحد (بدون تدرج)"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31044"
+msgid "Fade"
+msgstr "تلاشى"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31045"
+msgid "Transparent"
+msgstr "شفاف"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31046"
+msgid "Opaque"
+msgstr "عاتم"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31047"
+msgid "Divider Options"
+msgstr "خيارات تقسيم القوائم"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31048"
+msgid "Shadows"
+msgstr "الظلال"
+
+#: shortcuts/overrides.xml
+msgctxt "#31049"
+msgid "Default Widgets"
+msgstr "الودجيت الافتراضية"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31050"
+msgid "Title / Divider"
+msgstr ""
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31051"
+msgid "Classic"
+msgstr "كلاسيكي"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31052"
+msgid "Presets"
+msgstr "الإعدادات المسبقة"
+
+#: 1080i/Labels.xml
+msgctxt "#31053"
+msgid "Profile"
+msgstr "الملف الشخصي"
+
+#: 1080i/Labels.xml
+msgctxt "#31054"
+msgid "Liked by"
+msgstr "أعجب به"
+
+#: 1080i/Labels.xml
+msgctxt "#31055"
+msgid "out of"
+msgstr "من"
+
+#: 1080i/Labels.xml
+msgctxt "#31056"
+msgid "critics"
+msgstr "ناقد"
+
+#: 1080i/Objects.xml
+msgctxt "#31057"
+msgid "Years Old"
+msgstr "سنة"
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31058"
+msgid "Solid"
+msgstr ""
+
+#: 1080i/Custom_Backgrounds_1112.xml
+msgctxt "#31059"
+msgid "Split"
+msgstr ""
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31060"
+msgid "Premiered in"
+msgstr "عرض لأول مرة في"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31061"
+msgid "From"
+msgstr "من"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31062"
+msgid "By"
+msgstr "بواسطة"
+
+#: 1080i/Labels.xml
+msgctxt "#31063"
+msgid "Last Aired"
+msgstr "بثت آخر مرة"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31064"
+msgid "Awards"
+msgstr "الجوائز"
+
+#: 1080i/DialogVideoInfo.xml
+msgctxt "#31065"
+msgid "Creator"
+msgstr "المبتكر"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31066"
+msgid "Movies as Cast Member"
+msgstr "أفلام مثلّ فيها"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31067"
+msgid "TV Shows as Cast Member"
+msgstr "مسلسلات مثلّ فيها"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31068"
+msgid "Movies as Crew Member"
+msgstr "أفلام كعضو في طاقم الإنتاج"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31069"
+msgid "TV Shows as Crew Member"
+msgstr "مسلسلات كعضو في طاقم الإنتاج"
+
+#: 1080i/Custom_Recommend_1120.xml
+msgctxt "#31070"
+msgid "Posters"
+msgstr "البوسترات"
+
+#: 1080i/Labels.xml
+msgctxt "#31071"
+msgid "Playback Speed"
+msgstr "سرعة التشغيل"
+
+#: 1080i/Info.xml
+msgctxt "#31072"
+msgid "Ends at"
+msgstr "تنتهي المشاهدة عند"
+
+#: 1080i/Info.xml
+msgctxt "#31073"
+msgid "mins"
+msgstr "دقيقة"
+
+#: 1080i/Info.xml
+msgctxt "#31074"
+msgid "hr"
+msgstr "ساعة"
+
+#: 1080i/VideoOSD.xml
+msgctxt "#31075"
+msgid "Cast of"
+msgstr ""
+
+#: 1080i/Custom_Search_1117.xml
+msgctxt "#31076"
+msgid "Search by"
+msgstr "البحث بواسطة"
+
+#: 1080i/Home.xml
+msgctxt "#31077"
+msgid "More Information"
+msgstr "معلومات أكثر"
+
+#: shortcuts/overrides.xml
+msgctxt "#31078"
+msgid "Delete settings shortcut"
+msgstr "حذف اختصار الإعدادات"
+
+#: shortcuts/overrides.xml
+msgctxt "#31079"
+msgid ""
+"Are you sure you want to remove the settings shortcut?[CR]Please ensure that "
+"you have an alternative method of accessing settings before you remove this "
+"shortcut."
+msgstr ""
+"هل أنت متأكد أنك تريد إزالة اختصار الإعدادات؟ [CR] يرجى التأكد من أن لديك "
+"طريقة بديلة للوصول إلى الإعدادات قبل إزالة هذا الاختصار."
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31080"
+msgid "Customise home menu"
+msgstr "تخصيص القائمة الرئيسية"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31081"
+msgid "Action"
+msgstr "الإجراء"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31082"
+msgid "Select icon"
+msgstr "اختيار أيقونة"
+
+#: 1080i/AddonBrowser.xml
+msgctxt "#31083"
+msgid "Updates Available"
+msgstr "التحديثات المتوفرة"
+
+#: 1080i/AddonBrowser.xml
+msgctxt "#31084"
+msgid "Last Checked"
+msgstr "التحقق الأخير"
+
+#: shortcuts/mainmenu.DATA.xml
+msgctxt "#31085"
+msgid "Live TV"
+msgstr "البث المباشر"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31086"
+msgid "Customise power menu"
+msgstr "تخصيص قائمة الطاقة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31087"
+msgid "Menus / Widgets"
+msgstr "القوائم / الودجيت"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31088"
+msgid "Menus and widgets"
+msgstr "القوائم و الودجيت"
+
+#: shortcuts/overrides.xml
+msgctxt "#31089"
+msgid "Recently played"
+msgstr "شوهدت مؤخراً"
+
+#: shortcuts/overrides.xml
+msgctxt "#31090"
+msgid "In-Progress"
+msgstr "قيد التقدم"
+
+#: shortcuts/overrides.xml
+msgctxt "#31091"
+msgid "Top rated"
+msgstr "الأعلى تقييما"
+
+#: shortcuts/overrides.xml
+msgctxt "#31092"
+msgid "IMDb Top 250"
+msgstr ""
+
+#: shortcuts/overrides.xml
+msgctxt "#31093"
+msgid "Nodes"
+msgstr ""
+
+#: shortcuts/overrides.xml
+msgctxt "#31094"
+msgid "Random albums"
+msgstr "ألبومات عشوائية"
+
+#: shortcuts/overrides.xml
+msgctxt "#31095"
+msgid "Random artists"
+msgstr "فنانين عشوائيين"
+
+#: shortcuts/overrides.xml
+msgctxt "#31096"
+msgid "Active recordings"
+msgstr "التسجيلات النشطة"
+
+#: shortcuts/overrides.xml
+msgctxt "#31097"
+msgid "Grouped recordings"
+msgstr ""
+
+#: shortcuts/overrides.xml
+msgctxt "#31098"
+msgid "Grouped deleted recordings"
+msgstr ""
+
+#: shortcuts/overrides.xml
+msgctxt "#31099"
+msgid "Video Sources"
+msgstr "مصادر الفيديو"
+
+#: shortcuts/overrides.xml
+msgctxt "#31100"
+msgid "Music Sources"
+msgstr "مصادر الموسيقى"
+
+#: shortcuts/overrides.xml
+msgctxt "#31101"
+msgid "Picture Sources"
+msgstr "مصادر الصور"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31102"
+msgid "Fullscreen widget"
+msgstr "ودجيت بشاشة كاملة"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31103"
+msgid "Widgets"
+msgstr "الودجيت \"الأقسام\""
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31104"
+msgid "Choose widget"
+msgstr "اختيار الودجيت (القسم)"
+
+#: shortcuts/template.xml
+msgctxt "#31105"
+msgid "Spotlight"
+msgstr ""
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31106"
+msgid "Content type"
+msgstr "نوع المحتوى"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31107"
+msgid "Simple"
+msgstr "بسيط"
+
+#: 1080i/Custom_1114_Search.xml
+msgctxt "#31108"
+msgid "Collections"
+msgstr "المجموعات"
+
+#: 1080i/Custom_1114_Search.xml
+msgctxt "#31109"
+msgid "Tagged"
+msgstr "تم وضع علامة عليها"
+
+#: 1080i/Info.xml
+msgctxt "#31110"
+msgid "pages"
+msgstr "صفحات"
+
+#: 1080i/Views_Row.xml
+msgctxt "#31111"
+msgid "Poster Row"
+msgstr "بوستر-أفقية"
+
+#: 1080i/Views_Row.xml
+msgctxt "#31112"
+msgid "Landscape Row"
+msgstr "منظر-أفقية"
+
+#: 1080i/Views_Row.xml
+msgctxt "#31113"
+msgid "Square Row"
+msgstr "مربعة-أفقية"
+
+#: 1080i/Items.xml
+msgctxt "#31114"
+msgid "View"
+msgstr "طريقة العرض"
+
+#: 1080i/Views_Wall.xml
+msgctxt "#31115"
+msgid "Poster Wall"
+msgstr "بوستر-جدارية"
+
+#: 1080i/Views_Wall.xml
+msgctxt "#31116"
+msgid "Landscape Wall"
+msgstr "منظر-جدارية"
+
+#: 1080i/Views_Wall.xml
+msgctxt "#31117"
+msgid "Square Wall"
+msgstr "مربعة-جدارية"
+
+#: 1080i/Views_Combined.xml
+msgctxt "#31118"
+msgid "Poster Combined"
+msgstr "بوستر-مجتمعة"
+
+#: 1080i/Views_Combined.xml
+msgctxt "#31119"
+msgid "Landscape Combined"
+msgstr "منظر-مجتمعة"
+
+#: 1080i/Views_Combined.xml
+msgctxt "#31120"
+msgid "Square Combined"
+msgstr "مربعة-مجتمعة"
+
+#: 1080i/Views_List.xml
+msgctxt "#31121"
+msgid "Square List"
+msgstr "مربعة-قائمة"
+
+#: 1080i/Views_List.xml
+msgctxt "#31122"
+msgid "Landscape List"
+msgstr "منظر-قائمة"
+
+#: 1080i/Views_List.xml
+msgctxt "#31123"
+msgid "Infolist"
+msgstr "قائمة معلومات"
+
+#: 1080i/Custom_1111_Colours.xml
+msgctxt "#31124"
+msgid "Indicator"
+msgstr "المؤشر"
+
+#: 1080i/Custom_1111_Colours.xml
+msgctxt "#31125"
+msgid "Invert Text Colour"
+msgstr "عكس لون النص"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31126"
+msgid "Thin Font"
+msgstr "خط نحيف"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31127"
+msgid "Bold Font"
+msgstr "خط عريض"
+
+#: 1080i/Views_Wall.xml
+msgctxt "#31128"
+msgid "Big Poster Wall"
+msgstr "بوستر كبير-جدارية"
+
+#: 1080i/script-upnext-upnext.xml
+msgctxt "#31129"
+msgid "Up next in"
+msgstr "الحلقة التالية في"
+
+#: 1080i/script-upnext-upnext.xml
+msgctxt "#31130"
+msgid "seconds"
+msgstr "ثاني"
+
+#: 1080i/script-upnext-stillwatching.xml
+msgctxt "#31131"
+msgid "Continue watching in"
+msgstr "استمر في المشاهدة"
+
+#: 1080i/SmartPlaylistEditor.xml
+msgctxt "#31132"
+msgid "Rules"
+msgstr "الشروط"
+
+#: 1080i/SmartPlaylistEditor.xml
+msgctxt "#31133"
+msgid ""
+"Set the type and add rules to create a smart playlist. These playlists are "
+"dynamic and include all media items from your database which apply to your "
+"chosen rules."
+msgstr ""
+"عيّن النوع وأضف الشروط لإنشاء قائمة تشغيل ذكية. قوائم التشغيل هذه ديناميكية "
+"وتتضمن جميع عناصر الوسائط من قاعدة البيانات الخاصة بك والتي تنطبق على الشروط "
+"التي اخترتها."
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31134"
+msgid "Expand information"
+msgstr "عرض المعلومات"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31135"
+msgid "Divider"
+msgstr "مقسم"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31136"
+msgid "Select highlight colour preset"
+msgstr "حدد الإعداد المسبق للون الأساسي"
+
+#: 1080i/Custom_1115_PresetColors.xml
+msgctxt "#31137"
+msgid "Colour Presets"
+msgstr "الإعدادات المسبقة للون"
+
+#: 1080i/Custom_1115_PresetColors.xml
+msgctxt "#31138"
+msgid "Aqua Classic"
+msgstr ""
+
+#: 1080i/Custom_1115_PresetColors.xml
+msgctxt "#31139"
+msgid "Tropical Sunset"
+msgstr ""
+
+#: 1080i/Custom_1115_PresetColors.xml
+msgctxt "#31140"
+msgid "Miami Vaporwave"
+msgstr ""
+
+#: 1080i/Custom_1115_PresetColors.xml
+msgctxt "#31141"
+msgid "Plain Monochrome"
+msgstr ""
+
+#: 1080i/Info.xml
+msgctxt "#31142"
+msgid "Total Duration"
+msgstr "المدة الإجمالية"
+
+#: 1080i/Views_List.xml
+msgctxt "#31143"
+msgid "Square Infolist"
+msgstr "مربعة-قائمة معلومات"
+
+#: 1080i/Views_List.xml
+msgctxt "#31144"
+msgid "Landscape Infolist"
+msgstr "منظر-قائمة معلومات"
+
+#: 1080i/Custom_1198_Startup.xml
+msgctxt "#31145"
+msgid "Initialising Skin"
+msgstr "تهيئة المظهر"
+
+#: 1080i/Views.xml
+msgctxt "#31146"
+msgid "No items to display[CR]Add rules on the left menu to discover new items"
+msgstr "لا توجد عناصر لعرضها[CR]أضف شروط في القائمة اليسرى لاكتشاف عناصر جديدة"
+
+#: 1080i/Custom_1191_Testing.xml
+msgctxt "#31147"
+msgid "Aired"
+msgstr "بثت"
+
+#: 1080i/Views_Combined.xml
+msgctxt "#31148"
+msgid "Big Landscape Combined"
+msgstr "منظر كبير-مجتمعة"
+
+#: 1080i/Views_Row.xml
+msgctxt "#31149"
+msgid "Big Landscape Row"
+msgstr "منظر كبير-أفقية"
+
+#: 1080i/Views_Wall.xml
+msgctxt "#31150"
+msgid "Big Landscape Wall"
+msgstr "منظر كبير-جدارية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31151"
+msgid "Customise search menu"
+msgstr "تخصيص قائمة البحث"
+
+#: 1080i/Views_PVR.xml
+msgctxt "#31152"
+msgid "Detailed"
+msgstr "مفصلة"
+
+#: 1080i/MyPVRSearch.xml
+msgctxt "#31153"
+msgid "Results"
+msgstr "النتائج"
+
+#: 1080i/DialogPVRChannelManager.xml
+msgctxt "#31154"
+msgid "Misc options"
+msgstr "خيارات متنوعة"
+
+#: 1080i/DialogPVRGroupManager.xml
+msgctxt "#31155"
+msgid "Add Group"
+msgstr "أضف مجموعة"
+
+#: 1080i/DialogPVRGroupManager.xml
+msgctxt "#31156"
+msgid "Rename Group"
+msgstr "إعادة تسمية المجموعة"
+
+#: 1080i/DialogPVRGroupManager.xml
+msgctxt "#31157"
+msgid "Delete group"
+msgstr "حذف المجموعة"
+
+#: 1080i/Labels.xml
+msgctxt "#31158"
+msgid "Next Aired"
+msgstr "البث المقبل"
+
+#: 1080i/Layouts.xml
+msgctxt "#31159"
+msgid "No plot information available"
+msgstr "لا توجد معلومات عن الحبكة متاحة حاليا"
+
+#: 1080i/Labels.xml
+msgctxt "#31160"
+msgid "REC"
+msgstr ""
+
+#: shortcuts/overrides.xml
+msgctxt "#31161"
+msgid "Next Aired Library"
+msgstr "البث المقبل \"المكتبة\""
+
+#: shortcuts/overrides.xml
+msgctxt "#31162"
+msgid "Next Aired Trakt"
+msgstr "البث المقبل \"Trakt\""
+
+#: 1080i/Items.xml
+msgctxt "#31163"
+msgid "Vertical"
+msgstr "عمودي"
+
+#: 1080i/Items.xml
+msgctxt "#31164"
+msgid "Horizontal"
+msgstr "أفقي"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31165"
+msgid "Experimental"
+msgstr "تجريبي"
+
+#: shortcuts/videos-1.DATA.xml
+msgctxt "#31166"
+msgid "Popular"
+msgstr "الشائع"
+
+#: shortcuts/videos-1.DATA.xml
+msgctxt "#31167"
+msgid "Anticipated"
+msgstr "المرتقبة"
+
+#: shortcuts/searchmenu.DATA.xml
+msgctxt "#31168"
+msgid "TMDb Movies"
+msgstr "أفلام TMDb"
+
+#: shortcuts/searchmenu.DATA.xml
+msgctxt "#31169"
+msgid "TMDb TV Shows"
+msgstr "مسلسلات TMDb"
+
+#: shortcuts/searchmenu.DATA.xml
+msgctxt "#31170"
+msgid "TMDb Collections"
+msgstr "مجموعات TMDb"
+
+#: shortcuts/searchmenu.DATA.xml
+msgctxt "#31171"
+msgid "TMDb People"
+msgstr "أشخاص TMDb"
+
+#: 1080i/Views_Row.xml
+msgctxt "#31172"
+msgid "Big Poster Row"
+msgstr "بوستر كبير-أفقية"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31173"
+msgid "widget"
+msgstr "ودجيت"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31174"
+msgid "Navigation"
+msgstr "التنقل"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31175"
+msgid "Press back from EPG to open menu"
+msgstr "الضغط على زر \"الرجوع\" في الدليل \"EPG\" يفتح لك قائمة الخيارات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31176"
+msgid "Use simple background for standard widgets"
+msgstr "استخدم خلفية بسيطة للودجيت"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31177"
+msgid "Menus"
+msgstr "القوائم"
+
+#: shortcuts/overrides.xml
+msgctxt "#31178"
+msgid "Open Submenu"
+msgstr "فتح القائمة الفرعية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31179"
+msgid "Press up from home menu to open submenu"
+msgstr "الضغط على زر \"الأعلى\" في القائمة الرئيسية يفتح لك القائمة الفرعية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31180"
+msgid "Furniture"
+msgstr "التركيبات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31181"
+msgid "Weather with clock"
+msgstr "عرض الطقس مع الساعة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31182"
+msgid "Always display stop button"
+msgstr "عرض زر \"الإيقاف\" دائمًا"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31183"
+msgid "Label"
+msgstr "الاسم"
+
+#: 1080i/Labels.xml
+msgctxt "#31184"
+msgid "Wall"
+msgstr "طريقة عرض جدارية"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31185"
+msgid "Autoscroll"
+msgstr "التمرير التلقائي"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31186"
+msgid "Behaviour"
+msgstr "السلوك"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31187"
+msgid "Autoscroll time interval"
+msgstr "الفاصل الزمني للتمرير التلقائي"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31188"
+msgid "Limit"
+msgstr "حد عدد العناصر"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31189"
+msgid "Autoclose OSD after X seconds"
+msgstr "أغلق واجهة المشغل تلقائيًا بعد \"X\" ثانية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31190"
+msgid "Use EPGEventIcon for PVR background fanart"
+msgstr "استخدم ايقونة الدليل \"EPG\" كخلفية للـPVR"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31191"
+msgid "Aggregate full tv cast list"
+msgstr "تجميع قائمة الممثلين التلفزيونية الكاملة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31192"
+msgid "Aggregate full tv crew list"
+msgstr "تجميع قائمة طاقم الإنتاج التلفزيونية الكاملة"
+
+#: 1080i/Views_List.xml
+msgctxt "#31193"
+msgid "Square Playlist"
+msgstr "مربعة-قائمة تشغيل"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31194"
+msgid "Trailer button plays windowed"
+msgstr "تشغيل العرض الدعائي في وضع النافذة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31195"
+msgid "Profile image with clock"
+msgstr "عرض صورة الملف الشخصي مع الساعة"
+
+#: 1080i/Custom_1120_Recommend.xml
+msgctxt "#31196"
+msgid "Up Next"
+msgstr "الحلقة التالية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31197"
+msgid "Customise recommendations"
+msgstr "تخصيص قائمة المعلومات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31198"
+msgid "Customise ratings"
+msgstr "تخصيص التقييمات"
+
+#: 1080i/Items.xml
+msgctxt "#31199"
+msgid "Star"
+msgstr ""
+
+#: 1080i/Items.xml
+msgctxt "#31200"
+msgid "User"
+msgstr "المستخدم"
+
+#: 1080i/Items.xml
+msgctxt "#31201"
+msgid "Critic"
+msgstr "الناقد"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31202"
+msgid "Ratings"
+msgstr "التقييمات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31203"
+msgid "Customise"
+msgstr "مخصص"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31204"
+msgid "Use videowindow for background"
+msgstr "استخدم نافذة الفيديو كخلفية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31205"
+msgid "Press down from row view scrollbar opens"
+msgstr "الضغط على زر \"الأسفل\" في طريقة العرض \"الأفقية\" يفتح لك :"
+
+#: 1080i/Items.xml
+msgctxt "#31206"
+msgid "Ratings display placeholders when unavailable or updating"
+msgstr "عرض أيقونات التقييمات \"دائما\" أثناء تحديثها أو عدم توفر نتيجة لها"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31207"
+msgid "Codec info with full expanded widgets"
+msgstr "عرض معلومات الترميز في الودجيت بملء الشاشة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31208"
+msgid "Expand plot on recommendations"
+msgstr "قم بعرض الحبكة في التوصيات"
+
+#: 1080i/Items.xml
+msgctxt "#31209"
+msgid "Colour overlay"
+msgstr "لون الغشاء"
+
+#: 1080i/Items.xml
+msgctxt "#31210"
+msgid "Animate fanart"
+msgstr "خلفية متحركة \"fanart\""
+
+#: 1080i/Items.xml
+msgctxt "#31211"
+msgid "Artist slideshow"
+msgstr "عرض شرائح للفنان"
+
+#: 1080i/Items.xml
+msgctxt "#31212"
+msgid "Scrolling text"
+msgstr "نص متحرك"
+
+#: 1080i/Items.xml
+msgctxt "#31213"
+msgid "Visualisation settings"
+msgstr "إعدادات المؤثرات البصرية"
+
+#: 1080i/Items.xml
+msgctxt "#31214"
+msgid "Visualisation presets"
+msgstr "الإعدادات المسبقة للمؤثرات البصرية"
+
+#: 1080i/Items.xml
+msgctxt "#31215"
+msgid "Reviews"
+msgstr "المراجعات"
+
+#: 1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31216"
+msgid "Video decoder"
+msgstr "وحدة فك ترميز الفيديو"
+
+#: 1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31217"
+msgid "Pixel format"
+msgstr "تنسيق البيكسل"
+
+#: 1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31218"
+msgid "Memory usage"
+msgstr "استخدام الذاكرة"
+
+#: shortcuts/videos-1.DATA.xml
+msgctxt "#31219"
+msgid "Categories"
+msgstr "الفئات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31220"
+msgid "Customise viewtypes"
+msgstr "تخصيص طريقة العرض"
+
+#: 1080i/Custom_1112_Backgrounds.xml
+msgctxt "#31221"
+msgid "Borders"
+msgstr "حدود"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31222"
+msgid "Overlay"
+msgstr "غشاء"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31223"
+msgid "Gridlines"
+msgstr "خطوط الشبكة"
+
+#: 1080i/Custom_1120_Recommend.xml
+msgctxt "#31224"
+msgid "Written by"
+msgstr "أعمال كتبها"
+
+#: 1080i/Custom_1120_Recommend.xml
+msgctxt "#31225"
+msgid "Directed by"
+msgstr "أعمال للمخرج"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31226"
+msgid "Use extrafanart for fanart background"
+msgstr ""
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31227"
+msgid "Customise colours"
+msgstr "تخصيص الألوان"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31228"
+msgid "Customise background"
+msgstr "تخصيص الخلفية"
+
+#: 1080i/script-skinshortcuts.xml
+msgctxt "#31229"
+msgid "Submenu widget"
+msgstr "ودجيت كقائمة فرعية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31230"
+msgid "Reset all menus and widgets to defaults"
+msgstr "إعادة تعيين جميع القوائم والودجيت إلى الإعدادات الافتراضية"
+
+#: shortcuts/overrides.xml
+msgctxt "#31231"
+msgid "Auto-fit to width"
+msgstr "ضبط تلقائي للعرض"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31232"
+msgid "TMDbHelper look-ups for PVR windows"
+msgstr ""
+
+#: 1080i/Labels.xml
+msgctxt "#31233"
+msgid "Seek to"
+msgstr ""
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31234"
+msgid "Customise indicators"
+msgstr "تخصيص المؤشرات"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31235"
+msgid "Indicators"
+msgstr "المؤشرات"
+
+#: 1080i/Items.xml
+msgctxt "#31236"
+msgid "Collection"
+msgstr "مجموعة أعمال:"
+
+#: 1080i/Items.xml
+msgctxt "#31237"
+msgid "Progress"
+msgstr "التقدم"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31238"
+msgid "Header"
+msgstr "الرأس"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31239"
+msgid "Footer"
+msgstr "الهامش"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31240"
+msgid "Audio language flags"
+msgstr "عرض أعلام للغة الصوت"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31241"
+msgid "Subtitle language flags"
+msgstr "عرض أعلام للغة الترجمة"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31242"
+msgid "Media codec icons"
+msgstr "عرض أيقونات ترميز الوسائط (Codec icons)"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31243"
+msgid "Media provider icons"
+msgstr "عرض أيقونات مزود الوسائط"
+
+#: 1080i/DialogSeekBar.xml
+msgctxt "#31244"
+msgid "Now Playing"
+msgstr "قيد التشغيل الآن"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31245"
+msgid "Autoscroll labels"
+msgstr "التمرير التلقائي للعناوين"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31246"
+msgid "Autoscroll textboxes"
+msgstr "التمرير التلقائي لمربعات النص"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31247"
+msgid "Opaque texture for focused PVR widgets"
+msgstr "تعتيم عناصر ودجيت الـPVR المركز عليها"
+
+#: 1080i/Custom_1198_Startup.xml
+msgctxt "#31248"
+msgid "Building includes"
+msgstr ""
+
+#: 1080i/Custom_1198_Startup.xml
+msgctxt "#31249"
+msgid "Waiting for PVR"
+msgstr "في انتظار الـPVR"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31250"
+msgid "Search in home menu bar"
+msgstr "عرض قسم \"البحث\" في القائمة الرئيسية"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31251"
+msgid "Codecs displayed with seekbar"
+msgstr "عرض أيقونات الترميز مع شريط التقدم"
+
+#: 1080i/Items.xml
+msgctxt "#31252"
+msgid "Catch-up"
+msgstr "المتابعة"
+
+#: shortcuts/template.xml
+msgctxt "#31253"
+msgid "Show more"
+msgstr "عرض المزيد"
+
+#: 1080i/SkinSettings.xml
+msgctxt "#31254"
+msgid "Limited widgets have \"more items\" object"
+msgstr "إظهار عنصر \"عرض المزيد\" على الودجيت المحدودة"


### PR DESCRIPTION
this is an Arabic translation for AH2.
I also translate "script.skinvariables" please check it out. 

Anyway I encounter a couple issues while translating AH2:
First one is a missing strings or labels, idk if it in another add-on or not attach to strings.po file?!
the missing strings I found:
```
Revenue\Budget
Released
Returning Series
Ended
Highlight
Gradient
Indicator
Customise Startup image
Full (for "Expand Information")
Plot (for "Expand Information")
Resource Usage (in "Player Process Info")
Memory (in "Player Process Info")
CPU (in "Player Process Info")
```

Second: is a Bug ( Should i report it as "New issue" or on need for that?)
it is RLT bug, in the "Customize Appearance" window the "text" is overlapping on the "toggle buttons" while using Arabic as interface language

image of the Bug:
![Screenshot_17](https://user-images.githubusercontent.com/80945174/180595525-85152779-cebf-469e-b9c9-a5a0025e4042.png)

